### PR TITLE
Fix font flash (FOUT) on page load

### DIFF
--- a/src/_includes/layouts/application.njk
+++ b/src/_includes/layouts/application.njk
@@ -2,8 +2,18 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <!-- Flag set before paint so the auto-sized headings start hidden (see app.scss). -->
+    <script>document.documentElement.className += ' fonts-loading';</script>
     <title>Jake Fleming - Product Designer</title>
     <meta name="description" content="Jake Fleming is a Product Designer with specialties in Visual Design, Illustration, and Front-end coding">
+
+    <!-- Preload every web font so they're all ready before first paint and content reveals fast. -->
+    <link rel="preload" href="fonts/Industrious-WideBlack.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="fonts/Obviously-Regular.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="fonts/Obviously-Extended.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="fonts/Obviously-Narrow_Medium.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="fonts/Gooper0.2-BoldItalic.woff2" as="font" type="font/woff2" crossorigin>
+
     <link rel="stylesheet" href="stylesheets/app.css">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
@@ -48,22 +58,51 @@
       <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
       <script src="javascripts/app.js"></script>
       <script>
-        var ftw = new FontToWidth({
-      		elements:'.ftw h3',
-      		fonts: fonts
-          });
+        (function () {
+          var docEl = document.documentElement;
 
-          var stw = new FontToWidth({elements: '.stw .resize'});
+          function start() {
+            // Only run once, even if both the font promise and the safety net fire.
+            if (!docEl.classList.contains('fonts-loading')) return;
 
-          var remix = function() {
-              $.each($('form').serializeArray(), function(i, item) {
-                  ftw.options[item.name] = parseFloat(item.value) || item.value;
+            // Scale the display headings to fill their container.
+            var stw = new FontToWidth({ elements: '.stw .resize' });
+
+            // Multi-font fitter — only matches on pages that have `.ftw h3`.
+            var ftw = new FontToWidth({ elements: '.ftw h3', fonts: fonts });
+
+            var remix = function () {
+              $.each($('form').serializeArray(), function (i, item) {
+                ftw.options[item.name] = parseFloat(item.value) || item.value;
               });
               ftw.updateWidths();
-          };
+            };
+            $('input').on('change', remix);
+            remix();
 
-          $('input').on('change', remix);
-          remix();
+            // Fonts are loaded and headings are measured — reveal them.
+            docEl.classList.remove('fonts-loading');
+          }
+
+          // Wait until every web font is actually loaded before revealing, so
+          // no text is shown in a fallback and the headings are measured once
+          // against the real font (never fitted to the fallback and re-fitted).
+          if (document.fonts && document.fonts.load) {
+            Promise.all([
+              document.fonts.load('1em "Industrious"'),
+              document.fonts.load('1em "Obviously"'),
+              document.fonts.load('1em "Obviously Extended"'),
+              document.fonts.load('1em "Obviously Narrow"'),
+              document.fonts.load('1em "Gooper Bold Italic"')
+            ]).then(start, start);
+            // Safety net: reveal anyway if a font never resolves.
+            setTimeout(start, 3000);
+          } else if (document.readyState === 'complete') {
+            start();
+          } else {
+            window.addEventListener('load', start);
+          }
+        })();
       </script>
     {% endblock %}
   </body>

--- a/src/stylesheets/app.scss
+++ b/src/stylesheets/app.scss
@@ -1,16 +1,22 @@
 @import 'spectre/spectre';
 
 // fonts
+// `font-display: swap` paints text immediately in the fallback and swaps in
+// the web font as soon as it arrives (no invisible-text period). The big
+// auto-sized headings are additionally hidden until their font is measured —
+// see the `.fonts-loading` rule below — so they never visibly re-fit.
 @font-face {
   font-family: "Industrious";
   font-style: normal;
+  font-display: swap;
   src: url("../fonts/Industrious-WideBlack.woff2") format("woff2"),
-       url("../fonts/BIndustrious-WideBlack.woff") format("woff");
+       url("../fonts/Industrious-WideBlack.woff") format("woff");
 }
 
 @font-face {
   font-family: "Obviously Extended";
   font-style: normal;
+  font-display: swap;
   src: url("../fonts/Obviously-Extended.woff2") format("woff2"),
        url("../fonts/Obviously-Extended.woff") format("woff");
 }
@@ -18,6 +24,7 @@
 @font-face {
   font-family: "Obviously";
   font-style: normal;
+  font-display: swap;
   src: url("../fonts/Obviously-Regular.woff2") format("woff2"),
        url("../fonts/Obviously-Regular.woff") format("woff");
 }
@@ -25,6 +32,7 @@
 @font-face {
   font-family: "Obviously Narrow";
   font-style: normal;
+  font-display: swap;
   src: url("../fonts/Obviously-Narrow_Medium.woff2") format("woff2"),
        url("../fonts/Obviously-Narrow_Medium.woff") format("woff");
 }
@@ -32,14 +40,35 @@
 @font-face {
   font-family: "Gooper Bold Italic";
   font-style: normal;
+  font-display: swap;
   src: url("../fonts/Gooper0.2-BoldItalic.woff2") format("woff2"),
        url("../fonts/Gooper0.2-BoldItalic.woff") format("woff");
+}
+
+// The display headings are scaled to fit by FontToWidth. Keep them invisible
+// (their box still reserves space) until the web font is loaded and measured,
+// so the user never sees the fallback font get fitted and then swapped. The
+// `fonts-loading` class is set in <head> and removed by JS once ready; if JS
+// is unavailable the headings simply render normally.
+// Hold all page content until the web fonts are loaded, then fade it in, so
+// no text is ever shown in a fallback font and swapped. JS removes the
+// `fonts-loading` class once the fonts are ready (with a 3s safety net); the
+// `html` background matches `body` so the page shows a solid colour — not a
+// white flash — while content is held.
+html {
+  background: #f8f8f8;
 }
 
 body {
   font-family: "Obviously";
   font-feature-settings: "salt";
   background: #f8f8f8;
+  opacity: 1;
+  transition: opacity 0.2s ease-out;
+}
+
+.fonts-loading body {
+  opacity: 0;
 }
 
 main {


### PR DESCRIPTION
Eliminates the font flash on load — most visibly on the Industrious display headings driven by FontToWidth.

## Root causes fixed
1. **Broken font path** — the Industrious `.woff` fallback pointed at `BIndustrious-WideBlack.woff` (stray leading `B`), so that source 404'd.
2. **No `font-display`** on any `@font-face` → browser-default block/swap behavior.
3. **The visible jump:** FontToWidth fitted the big `.stw` headings to the *fallback* font on DOM-ready, then the real font swapped in at different widths, then it re-fit on window-load — a double reflow.

## Approach
- Fix the `.woff` path; add `font-display: swap` to every `@font-face`.
- Hold all page content (`body` opacity) until **every** web font is loaded via the CSS Font Loading API, then fade it in (0.2s) — so no text is ever shown in a fallback and swapped. `html` is backgrounded to match `body` so there's no white flash while content is held.
- Preload all five web fonts so the hold is brief.
- Defer FontToWidth until the fonts are loaded, so the auto-sized headings are measured once against the real font.
- Safety net: 3s timeout + a no-Font-Loading-API fallback guarantee content always reveals.

## Verification
- Build is clean; the previously-404'ing Industrious `.woff` and all preloaded fonts now serve `200`.

Trade-off: favors zero-swap over fastest-text — a brief (preload-bounded, ≤3s) colored-background hold before fade-in.

https://claude.ai/code/session_01PkanDRnqxFR2gPfRrAUAsh

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkanDRnqxFR2gPfRrAUAsh)_