### PR TITLE
Add hidden /lab/sprites page (pure-SVG animations) + nested-page fixes

### DIFF
--- a/src/_includes/layouts/application.njk
+++ b/src/_includes/layouts/application.njk
@@ -8,13 +8,13 @@
     <meta name="description" content="Jake Fleming is a Product Designer with specialties in Visual Design, Illustration, and Front-end coding">
 
     <!-- Preload every web font so they're all ready before first paint and content reveals fast. -->
-    <link rel="preload" href="fonts/Industrious-WideBlack.woff2" as="font" type="font/woff2" crossorigin>
-    <link rel="preload" href="fonts/Obviously-Regular.woff2" as="font" type="font/woff2" crossorigin>
-    <link rel="preload" href="fonts/Obviously-Extended.woff2" as="font" type="font/woff2" crossorigin>
-    <link rel="preload" href="fonts/Obviously-Narrow_Medium.woff2" as="font" type="font/woff2" crossorigin>
-    <link rel="preload" href="fonts/Gooper0.2-BoldItalic.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="/fonts/Industrious-WideBlack.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="/fonts/Obviously-Regular.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="/fonts/Obviously-Extended.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="/fonts/Obviously-Narrow_Medium.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="/fonts/Gooper0.2-BoldItalic.woff2" as="font" type="font/woff2" crossorigin>
 
-    <link rel="stylesheet" href="stylesheets/app.css">
+    <link rel="stylesheet" href="/stylesheets/app.css">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png">
@@ -56,31 +56,36 @@
     {% block content %}{% endblock %}
     {% block javascript %}
       <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-      <script src="javascripts/app.js"></script>
+      <script src="/javascripts/app.js"></script>
       <script>
         (function () {
           var docEl = document.documentElement;
 
+          var started = false;
           function start() {
-            // Only run once, even if both the font promise and the safety net fire.
-            if (!docEl.classList.contains('fonts-loading')) return;
+            if (started) return; // run once, whether triggered by fonts or the safety net
+            started = true;
 
-            // Scale the display headings to fill their container.
-            var stw = new FontToWidth({ elements: '.stw .resize' });
+            // Fit the display headings to their container. This is a
+            // progressive enhancement: if FontToWidth or jQuery is unavailable
+            // (e.g. the CDN fails), skip it — but always reveal the page so a
+            // failed dependency can never leave the site blank.
+            try {
+              var stw = new FontToWidth({ elements: '.stw .resize' });
 
-            // Multi-font fitter — only matches on pages that have `.ftw h3`.
-            var ftw = new FontToWidth({ elements: '.ftw h3', fonts: fonts });
+              // Multi-font fitter — only matches on pages that have `.ftw h3`.
+              var ftw = new FontToWidth({ elements: '.ftw h3', fonts: fonts });
 
-            var remix = function () {
-              $.each($('form').serializeArray(), function (i, item) {
-                ftw.options[item.name] = parseFloat(item.value) || item.value;
-              });
-              ftw.updateWidths();
-            };
-            $('input').on('change', remix);
-            remix();
+              var remix = function () {
+                $.each($('form').serializeArray(), function (i, item) {
+                  ftw.options[item.name] = parseFloat(item.value) || item.value;
+                });
+                ftw.updateWidths();
+              };
+              $('input').on('change', remix);
+              remix();
+            } catch (e) { /* heading auto-fit is optional */ }
 
-            // Fonts are loaded and headings are measured — reveal them.
             docEl.classList.remove('fonts-loading');
           }
 

--- a/src/lab/sprites.njk
+++ b/src/lab/sprites.njk
@@ -1,0 +1,123 @@
+{#
+  Hidden lab page — not linked from anywhere and flagged noindex.
+  Reproduces the home page's CSS sprite-sheet animations using *pure SVG*:
+  each animation is an <svg> viewport exactly one frame wide, with the
+  original sprite sheet placed inside as an <image> and stepped through its
+  frames by a SMIL <animateTransform calcMode="discrete">. No background-
+  position trick, no JavaScript — the motion lives entirely in the SVG.
+#}
+
+{% extends 'layouts/application.njk' %}
+
+{#
+  Render one pure-SVG sprite animation.
+  file  — sprite sheet basename in /images (a horizontal strip of frames)
+  frames, size — frame count and per-frame px (sheet width = size * frames)
+  dur   — full loop duration (matches the original CSS animation)
+#}
+{% macro spriteSVG(file, frames, size, dur, label) %}
+<svg class="sprite" width="{{ size }}" height="{{ size }}" viewBox="0 0 {{ size }} {{ size }}"
+     overflow="hidden" role="img" aria-label="{{ label }}">
+  <g>
+    <animateTransform attributeName="transform" attributeType="XML" type="translate"
+      calcMode="discrete" dur="{{ dur }}" repeatCount="indefinite"
+      values="{% for i in range(0, frames) %}{{ (0 - i) * size }},0{% if not loop.last %};{% endif %}{% endfor %}"/>
+    <image href="/images/{{ file }}.svg" xlink:href="/images/{{ file }}.svg"
+           width="{{ size * frames }}" height="{{ size }}"/>
+  </g>
+</svg>
+{% endmacro %}
+
+{% block head %}
+  <meta name="robots" content="noindex, nofollow">
+  <style>
+    .lab {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 3rem 2rem 5rem;
+    }
+    .lab__intro {
+      font-family: "Obviously Narrow", sans-serif;
+      color: #555;
+      max-width: 38rem;
+      margin: 0 auto 3rem;
+      text-align: center;
+      line-height: 1.5;
+    }
+    .lab__grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 1.5rem;
+    }
+    .lab__cell {
+      background: #fff;
+      border: 1px solid #ececec;
+      border-radius: 8px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: flex-end;
+      padding: 1rem;
+      min-height: 240px;
+    }
+    .lab__cell .sprite {
+      display: block;
+    }
+    /* artdesign frames are 200px — let it size to its own viewport */
+    .lab__name {
+      font-family: "Obviously Narrow", sans-serif;
+      text-transform: uppercase;
+      letter-spacing: .5px;
+      font-size: 13px;
+      color: #888;
+      margin-top: .75rem;
+    }
+    .lab__name code { color: #FB3600; }
+  </style>
+{% endblock %}
+
+{% block content %}
+<main>
+  <section class="section">
+    <div class="lab">
+      <div class="stw p-relative">
+        <h3 class="text-center resize">Pure SVG</h3>
+      </div>
+      <p class="lab__intro">
+        The same characters from the home page, but no longer CSS sprite sheets
+        stepped with <code>background-position</code>. Each one here is an inline
+        <code>&lt;svg&gt;</code> framed to a single cell, with the original sprite
+        strip stepped through its frames by a SMIL
+        <code>&lt;animateTransform&gt;</code> — no JavaScript, no CSS animation.
+      </p>
+
+      <div class="lab__grid">
+        <div class="lab__cell">
+          {{ spriteSVG("guy-jogging", 8, 160, "0.6s", "A figure jogging") }}
+          <span class="lab__name">guy-jogging</span>
+        </div>
+        <div class="lab__cell">
+          {{ spriteSVG("csshtml-walking", 8, 160, "0.6s", "CSS &amp; HTML character walking") }}
+          <span class="lab__name">csshtml-walking</span>
+        </div>
+        <div class="lab__cell">
+          {{ spriteSVG("perfection-walking", 4, 160, "0.3s", "Perfection character walking") }}
+          <span class="lab__name">perfection-walking</span>
+        </div>
+        <div class="lab__cell">
+          {{ spriteSVG("sanity-hopping", 5, 160, "0.4s", "Sanity character hopping") }}
+          <span class="lab__name">sanity-hopping</span>
+        </div>
+        <div class="lab__cell">
+          {{ spriteSVG("js-flying", 5, 160, "0.5s", "JavaScript character flying") }}
+          <span class="lab__name">js-flying</span>
+        </div>
+        <div class="lab__cell">
+          {{ spriteSVG("artdesign-crawling", 5, 200, "0.5s", "Art &amp; design character crawling") }}
+          <span class="lab__name">artdesign-crawling</span>
+        </div>
+      </div>
+    </div>
+  </section>
+</main>
+{% endblock %}


### PR DESCRIPTION
Adds a hidden lab page that reproduces the home page's CSS sprite-sheet character animations using **pure SVG** — and fixes two issues surfaced by building a nested page.

## New page — `/lab/sprites/`
- Unlinked from the site and marked `noindex, nofollow`.
- Each of the six characters is an `<svg>` viewport one frame wide, containing the original sprite strip as an `<image>`, stepped through its frames by a SMIL `<animateTransform calcMode="discrete">`. No `background-position`, no JavaScript — the motion lives entirely in the SVG.
- A Nunjucks macro computes per-sprite frame offsets/timing to match the originals exactly (e.g. guy-jogging 8 frames `0…-1120` @0.6s; artdesign 5 frames `0…-800` @200px @0.5s).
- Verified headlessly: each sprite renders clipped to a single frame (not the full strip), and 6 captures over time show 6 distinct frames (confirming it animates).

## Fixes surfaced while building a nested page
1. **Absolute asset paths** — the layout referenced `app.css`/`app.js`/fonts relatively, which only resolves at the site root; nested pages (`/buoyant-test/`, the new lab page) 404'd. Now absolute (`/stylesheets/...`), identical behavior at root.
2. **Failure-proof reveal** — the page reveal was coupled to FontToWidth/jQuery succeeding, so a jQuery-CDN failure could leave the live site blank. The heading auto-fit now runs in try/catch and the page always reveals.

https://claude.ai/code/session_01PkanDRnqxFR2gPfRrAUAsh

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkanDRnqxFR2gPfRrAUAsh)_